### PR TITLE
Add Notes Per Octave to Sequencer

### DIFF
--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
@@ -170,6 +170,7 @@ float S1DSPKernel::getTuningTable(int index) {
 
 void S1DSPKernel::setTuningTableNPO(int npo) {
     tuningTableNPO.store(npo);
+    sequencer.setNotesPerOctave(npo);
 }
 
 

--- a/AudioKitSynthOne/DSP/Sequencer/S1Sequencer.hpp
+++ b/AudioKitSynthOne/DSP/Sequencer/S1Sequencer.hpp
@@ -6,6 +6,7 @@
 //  Copyright © 2019 AudioKit. All rights reserved.
 //
 #include <array>
+#include <atomic>
 #include <functional>
 #include <list>
 #include <vector>
@@ -33,6 +34,7 @@ public:
     void setSampleRate(double sampleRate);
     void init();
     void reset(bool resetNotes);
+    void setNotesPerOctave(int notes);
 
     int getArpBeatCount();
     void process(DSPParameters &params, AEArray *heldNoteNumbersAE);
@@ -56,7 +58,7 @@ private:
     ///once init'd: sequencerLastNotes can be accessed and mutated only within process and resetDSP
     std::list<int> sequencerLastNotes;
 
-    int notesPerOctave = 12;
+    std::atomic<int> mNotesPerOctave{12};
 
     // Change notifications
     BeatCounterChangedCallback mBeatCounterDidChange;


### PR DESCRIPTION
Add setter/getter functions to be called whenever
the tuning table changes NPO.

here we go @marcussatellite :)